### PR TITLE
Support text attribute if no title was provided + argument usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ you can build the docker container and run with
 docker run -it -v '/path/to/opml.opml:/input.opml' -v '/path/to/output_dir:/output' podsnatch
 ```
 
+If you want to limit episodes for download, use `-n` argument. Say, for download last 3 episodes, of each podcast you need specify your command to:
+```bash
+python podsnatch.py --opml <input file> -o <output directory> -n 3
+```
+
 ## Contributing
 PRs welcone!

--- a/podsnatch.py
+++ b/podsnatch.py
@@ -17,10 +17,12 @@ TMP_EXT = '.part'
 class Show:
 
   def __init__(self, outline_element):
-    self.title = outline_element.get('title')
     self.url = (outline_element.get('xmlUrl') or
                 outline_element.get('xmlurl') or
                 None)
+    self.title = (outline_element.get('title') or
+                  outline_element.get('text')[0:50] or
+                  self.url.split('/')[-1])
     self.episode_guids = []
 
   def __str__(self):

--- a/podsnatch.py
+++ b/podsnatch.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
                       help='location to save podcasts')
   parser.add_argument('--number-of-episodes', '-n', dest='ep_cnt',
                       action='store', default=None,
-                      help='path to opml file to import')
+                      help='how many episodes to download. By default - download all')
   args = parser.parse_args()
 
   signal.signal(signal.SIGINT, ctrl_c_handler)


### PR DESCRIPTION
I ran into problem, that exported .opml file from airsonic doesn't work correctly with podsnatch. After small debug, I reach out that it uses text attribute for outline tag, instead of using title.

I made a support of text attribute if no title attribute was provided. And for critical case, if no title and text attribute specified - use last part of provided url.

And documented use of --number-of-episodes argument.